### PR TITLE
Fix future plan indexing

### DIFF
--- a/tinyphysics.py
+++ b/tinyphysics.py
@@ -154,10 +154,10 @@ class TinyPhysicsSimulator:
       State(roll_lataccel=state['roll_lataccel'], v_ego=state['v_ego'], a_ego=state['a_ego']),
       state['target_lataccel'],
       FuturePlan(
-        lataccel=self.data['target_lataccel'].values[step_idx + 1:step_idx + FUTURE_PLAN_STEPS].tolist(),
-        roll_lataccel=self.data['roll_lataccel'].values[step_idx + 1:step_idx + FUTURE_PLAN_STEPS].tolist(),
-        v_ego=self.data['v_ego'].values[step_idx + 1:step_idx + FUTURE_PLAN_STEPS].tolist(),
-        a_ego=self.data['a_ego'].values[step_idx + 1:step_idx + FUTURE_PLAN_STEPS].tolist()
+        lataccel=self.data['target_lataccel'].values[step_idx + 1:step_idx + FUTURE_PLAN_STEPS + 1].tolist(),
+        roll_lataccel=self.data['roll_lataccel'].values[step_idx + 1:step_idx + FUTURE_PLAN_STEPS + 1].tolist(),
+        v_ego=self.data['v_ego'].values[step_idx + 1:step_idx + FUTURE_PLAN_STEPS + 1].tolist(),
+        a_ego=self.data['a_ego'].values[step_idx + 1:step_idx + FUTURE_PLAN_STEPS + 1].tolist()
       )
     )
 


### PR DESCRIPTION
## Summary
- ensure `FuturePlan` slices include all `FUTURE_PLAN_STEPS`

## Testing
- `pip install -r requirements.txt`
- `python - <<'EOF'
import pandas as pd, numpy as np, os
from tinyphysics import TinyPhysicsSimulator
from controllers.zero import Controller as ZeroController
n=600
fname='temp_data.csv'
df=pd.DataFrame({'roll':np.zeros(n),'vEgo':np.ones(n),'aEgo':np.zeros(n),'targetLateralAcceleration':np.linspace(0,1,n),'steerCommand':np.zeros(n)})
df.to_csv(fname, index=False)
class DummyModel:
    def get_current_lataccel(self, *a, **kw):
        return 0.0
sim=TinyPhysicsSimulator(DummyModel(), fname, ZeroController(), debug=False)
state,target,future_plan=sim.get_state_target_futureplan(sim.step_idx)
print('future plan length',len(future_plan.lataccel))
os.remove(fname)
EOF

------
https://chatgpt.com/codex/tasks/task_e_688d5a5782a8832d93b6b00be2e157d1