### PR TITLE
Refactor temp controller generation to use temporary directories

### DIFF
--- a/optimization/blender_tournament_optimizer.py
+++ b/optimization/blender_tournament_optimizer.py
@@ -249,30 +249,42 @@ def evaluate_blender_architecture(architecture, training_data, data_files, model
     
     # Get best PID parameters from archive for evaluation
     pid_pairs = get_top_pid_pairs_from_archive()
-    
+
     total_costs = []
-    
+
     # Evaluate on subset of data files
     eval_files = random.sample(data_files, k=min(max_files, len(data_files)))
-    
-    for data_file in eval_files:
-        for pid1_params, pid2_params in pid_pairs[:3]:  # Top 3 PID pairs
-            
-            # Create temporary neural controller using new pattern
-            controller_module = _make_temp_neural_controller(pid1_params, pid2_params, onnx_path, architecture['id'])
-            
-            try:
-                # Evaluate using existing run_rollout pattern
-                cost, _, _ = run_rollout(data_file, controller_module, model)
-                total_costs.append(cost["total_cost"])
-                
-            except Exception as e:
-                print(f"    Evaluation failed: {e}")
-                total_costs.append(1000)  # Penalty for failed evaluation
-                
-            finally:
-                # Clean up temporary controller
-                cleanup_temp_controller(controller_module)
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        sys.path.append(tmp_dir)
+        import controllers
+        controllers.__path__.append(tmp_dir)
+        try:
+            for data_file in eval_files:
+                for pid1_params, pid2_params in pid_pairs[:3]:  # Top 3 PID pairs
+
+                    controller_module = _make_temp_neural_controller(
+                        pid1_params, pid2_params, onnx_path, architecture['id'], Path(tmp_dir)
+                    )
+
+                    full_module = f"controllers.{controller_module}"
+                    if full_module in sys.modules:
+                        del sys.modules[full_module]
+
+                    try:
+                        cost, _, _ = run_rollout(data_file, controller_module, model)
+                        total_costs.append(cost["total_cost"])
+
+                    except Exception as e:
+                        print(f"    Evaluation failed: {e}")
+                        total_costs.append(1000)
+
+                    finally:
+                        if full_module in sys.modules:
+                            del sys.modules[full_module]
+        finally:
+            controllers.__path__.remove(tmp_dir)
+            sys.path.remove(tmp_dir)
     
     neural_cost = np.mean(total_costs) if total_costs else 1000
     
@@ -280,23 +292,18 @@ def evaluate_blender_architecture(architecture, training_data, data_files, model
     # Always return actual neural performance without penalty
     return neural_cost
 
-def _make_temp_neural_controller(pid1_params, pid2_params, onnx_path, arch_id):
-    """Create temporary neural controller using new pattern"""
+def _make_temp_neural_controller(pid1_params, pid2_params, onnx_path, arch_id, target_dir: Path):
+    """Create temporary neural controller in target_dir"""
     from optimization import generate_neural_blended_controller
-    
-    controller_content = generate_neural_blended_controller(pid1_params, pid2_params, onnx_path)
-    module_name = f"temp_neural_{hashlib.md5((str(arch_id) + onnx_path).encode()).hexdigest()[:8]}"
-    
-    with open(f"controllers/{module_name}.py", "w") as f:
-        f.write(controller_content)
-    
-    return module_name
 
-def cleanup_temp_controller(module_name):
-    """Clean up temporary controller file"""
-    temp_path = f"controllers/{module_name}.py"
-    if os.path.exists(temp_path):
-        os.remove(temp_path)
+    controller_content = generate_neural_blended_controller(pid1_params, pid2_params, onnx_path)
+    Path(target_dir).mkdir(parents=True, exist_ok=True)
+    module_name = f"temp_neural_{hashlib.md5((str(arch_id) + onnx_path).encode()).hexdigest()[:8]}"
+
+    with open(Path(target_dir) / f"{module_name}.py", "w") as f:
+        f.write(controller_content)
+
+    return module_name
 
 def get_top_pid_pairs_from_archive(archive_path="plans/tournament_archive.json"):
     """Get top PID parameter pairs from tournament archive"""

--- a/optimization/tournament_optimizer.py
+++ b/optimization/tournament_optimizer.py
@@ -9,6 +9,7 @@ import argparse
 from typing import List, Dict, Any, Optional
 import sys
 import os
+import tempfile
 
 # Add the parent directory to path to find tinyphysics
 current_dir = os.path.dirname(os.path.abspath(__file__))
@@ -53,49 +54,47 @@ def extract_gains_from_champion(champion: Dict) -> tuple:
     """Extract low_gains and high_gains from either format"""
     return champion['low_gains'], champion['high_gains']
 
-def _make_temp_controller(ps: ParameterSet) -> str:
-    """Generate temporary controller file for evaluation."""
+def _make_temp_controller(ps: ParameterSet, target_dir: Path) -> str:
+    """Generate temporary controller file for evaluation inside target_dir."""
     content = generate_blended_controller(ps.low_gains, ps.high_gains)
-    controllers_dir = Path(__file__).parent.parent / "controllers"
+    Path(target_dir).mkdir(parents=True, exist_ok=True)
     module_name = f"temp_{ps.id.replace('-', '')}"
-    file_path = controllers_dir / f"{module_name}.py"
+    file_path = Path(target_dir) / f"{module_name}.py"
     with open(file_path, "w") as f:
         f.write(content)
     return module_name
 
-def cleanup_controllers(prefix: str = "temp_") -> None:
-    """Remove temporary controller files."""
-    controllers_dir = Path(__file__).parent.parent / "controllers"
-    for path in controllers_dir.glob(f"{prefix}*.py"):
-        try:
-            path.unlink()
-        except:
-            pass
-
 def evaluate(ps: ParameterSet, data_files: List[str], model: TinyPhysicsModel, max_files: int, rng: Optional[np.random.Generator] = None) -> None:
     """Evaluate a ParameterSet and populate its stats."""
-    import sys
-    mod = _make_temp_controller(ps)
-    full_module = f"controllers.{mod}"
-    if full_module in sys.modules:
-        del sys.modules[full_module]
+    import controllers
+
     total_costs = []
-    try:
-        # Sample a random subset of files for each evaluation
-        if rng is not None:
-            selected = rng.choice(data_files, size=min(max_files, len(data_files)), replace=False)
-        else:
-            selected = data_files[:max_files]
-        
-        for file in selected:
-            cost, _, _ = run_rollout(file, mod, model, debug=False)
-            total_costs.append(cost["total_cost"])
-    except:
-        pass
-    finally:
-        cleanup_controllers(prefix=f"temp_{ps.id.replace('-', '')}")
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        sys.path.append(tmp_dir)
+        controllers.__path__.append(tmp_dir)
+
+        mod = _make_temp_controller(ps, Path(tmp_dir))
+        full_module = f"controllers.{mod}"
         if full_module in sys.modules:
             del sys.modules[full_module]
+
+        try:
+            if rng is not None:
+                selected = rng.choice(data_files, size=min(max_files, len(data_files)), replace=False)
+            else:
+                selected = data_files[:max_files]
+
+            for file in selected:
+                cost, _, _ = run_rollout(file, mod, model, debug=False)
+                total_costs.append(cost["total_cost"])
+        except Exception:
+            pass
+        finally:
+            if full_module in sys.modules:
+                del sys.modules[full_module]
+            controllers.__path__.remove(tmp_dir)
+            sys.path.remove(tmp_dir)
+
     if total_costs:
         arr = np.array(total_costs)
         ps.stats = {


### PR DESCRIPTION
## Summary
- refactor controller helpers to write modules into a provided temp directory
- update tournament and blender optimizers to evaluate controllers from temporary locations and clean up automatically

## Testing
- `python -m pytest -q` *(fails: run_tournament missing arguments; ParameterSet attribute; etc.)*


------
https://chatgpt.com/codex/tasks/task_e_688fc567fb40832db6a6b17fc2ba6f59