### PR TITLE
Add validation tracking to BlenderNet training

### DIFF
--- a/run_complete_training_pipeline.py
+++ b/run_complete_training_pipeline.py
@@ -156,16 +156,20 @@ def run_stage_4_data_generation(args):
     # Train BlenderNet on generated data
     from neural_blender_net import train_blender_net_from_json
 
-    final_loss = train_blender_net_from_json(
+    results = train_blender_net_from_json(
         args.stage4_output_data,
         epochs=args.stage4_epochs,
         batch_size=args.stage4_batch_size,
         model_output=args.stage4_model_output,
     )
 
-    # Report training results including final loss and model path
+    # Report training results including final and validation loss
     print_results_summary(
-        f"Pre-Training - Loss {final_loss:.4f}", args.stage4_model_output
+        (
+            "Pre-Training - "
+            f"Train {results['train_loss']:.4f}, Val {results['val_loss']:.4f}"
+        ),
+        args.stage4_model_output,
     )
     return True
 


### PR DESCRIPTION
## Summary
- split BlenderNet JSON samples into train/validation sets
- log training and validation losses per epoch and track best validation loss
- expose final metrics for pipeline display

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68901ea0a19c832db1cf1be32706bbe3