### PR TITLE
Add feature normalization stats to Blender training pipeline

### DIFF
--- a/generate_blender_training_data.py
+++ b/generate_blender_training_data.py
@@ -132,6 +132,11 @@ def save_training_data(training_samples, output_path):
     """Save training data to JSON file."""
     output_path = Path(output_path)
     output_path.parent.mkdir(parents=True, exist_ok=True)
+    # Compute feature statistics for normalization
+    feature_array = np.array([s[0] for s in training_samples], dtype=np.float32)
+    feature_means = feature_array.mean(axis=0).tolist()
+    feature_stds = feature_array.std(axis=0).tolist()
+
     data = {
         'num_samples': len(training_samples),
         'feature_names': [
@@ -139,6 +144,10 @@ def save_training_data(training_samples, output_path):
             'error_integral', 'error_derivative',
             'future_lataccel_mean', 'future_lataccel_std'
         ],
+        'feature_stats': {
+            'mean': feature_means,
+            'std': feature_stds,
+        },
         'samples': [
             {'features': s[0], 'blend_weight': s[1]}
             for s in training_samples

--- a/neural_blender_net.py
+++ b/neural_blender_net.py
@@ -48,25 +48,40 @@ class BlenderNet(nn.Module):
     def forward(self, x):
         return self.network(x)
     
-    def extract_features(self, state, error, error_integral, error_derivative, future_plan):
+    def extract_features(self, state, error, error_integral, error_derivative, future_plan, stats=None):
         """
-        Extract 8-dimensional feature vector from control state
-        
+        Extract 8-dimensional feature vector from control state.
+
         Features:
-        [v_ego, roll_lataccel, a_ego, error, error_integral, error_derivative, 
+        [v_ego, roll_lataccel, a_ego, error, error_integral, error_derivative,
          future_lataccel_mean, future_lataccel_std]
+
+        Args:
+            state: Vehicle state object.
+            error: Lateral control error.
+            error_integral: Integral of error.
+            error_derivative: Derivative of error.
+            future_plan: Plan containing future lateral accelerations.
+            stats: Optional dictionary with 'mean' and 'std' lists for
+                feature normalization.
         """
         features = np.array([
             state.v_ego,
             state.roll_lataccel,
-            state.a_ego, 
+            state.a_ego,
             error,
             error_integral,
             error_derivative,
             np.mean(future_plan.lataccel) if len(future_plan.lataccel) > 0 else 0.0,
             np.std(future_plan.lataccel) if len(future_plan.lataccel) > 0 else 0.0
         ], dtype=np.float32)
-        
+
+        if stats and 'mean' in stats and 'std' in stats:
+            mean = np.array(stats['mean'], dtype=np.float32)
+            std = np.array(stats['std'], dtype=np.float32)
+            std[std == 0] = 1.0
+            features = (features - mean) / std
+
         return torch.tensor(features).unsqueeze(0)
     
     def export_to_onnx(self, onnx_path, input_size=8):
@@ -197,12 +212,19 @@ def train_blender_net_from_json(
     if not samples:
         raise ValueError(f"No training samples found in {data_path}")
 
-    features = torch.tensor(
-        [s["features"] for s in samples], dtype=torch.float32
-    )
-    labels = torch.tensor(
-        [s["blend_weight"] for s in samples], dtype=torch.float32
-    ).unsqueeze(1)
+    features = torch.tensor([s["features"] for s in samples], dtype=torch.float32)
+    labels = torch.tensor([s["blend_weight"] for s in samples], dtype=torch.float32).unsqueeze(1)
+
+    # Load feature statistics for normalization
+    stats = data.get("feature_stats", {})
+    if "mean" in stats and "std" in stats:
+        mean = torch.tensor(stats["mean"], dtype=torch.float32)
+        std = torch.tensor(stats["std"], dtype=torch.float32)
+    else:
+        mean = features.mean(dim=0)
+        std = features.std(dim=0)
+    std[std == 0] = 1.0
+    features = (features - mean) / std
 
     dataset = TensorDataset(features, labels)
     loader = DataLoader(dataset, batch_size=batch_size, shuffle=True)

--- a/robust_training_data_gen.py
+++ b/robust_training_data_gen.py
@@ -7,6 +7,8 @@ import json
 import random
 from pathlib import Path
 
+import numpy as np
+
 def generate_training_data():
     """Generate training data from tournament archive with error handling"""
     
@@ -109,7 +111,12 @@ def generate_training_data():
             print(f"  Completed {combo_idx + 1}/{len(top_performers)} combinations")
     
     print(f"Generated {len(training_samples)} training samples")
-    
+
+    # Compute feature statistics for normalization
+    feature_array = np.array([s[0] for s in training_samples], dtype=np.float32)
+    feature_means = feature_array.mean(axis=0).tolist()
+    feature_stds = feature_array.std(axis=0).tolist()
+
     # Save training data
     training_data = {
         'num_samples': len(training_samples),
@@ -117,9 +124,13 @@ def generate_training_data():
         'top_performers_used': len(top_performers),
         'feature_names': [
             'v_ego', 'roll_lataccel', 'a_ego', 'error',
-            'error_integral', 'error_derivative', 
+            'error_integral', 'error_derivative',
             'future_lataccel_mean', 'future_lataccel_std'
         ],
+        'feature_stats': {
+            'mean': feature_means,
+            'std': feature_stds,
+        },
         'samples': [
             {
                 'features': sample[0],

--- a/simple_training_data_gen.py
+++ b/simple_training_data_gen.py
@@ -8,6 +8,8 @@ import math
 import random
 from pathlib import Path
 
+import numpy as np
+
 def generate_training_data():
     """Generate training data from tournament archive"""
     
@@ -69,15 +71,24 @@ def generate_training_data():
             training_samples.append((features, optimal_blend))
     
     print(f"Generated {len(training_samples)} training samples")
-    
+
+    # Compute feature statistics for normalization
+    feature_array = np.array([s[0] for s in training_samples], dtype=np.float32)
+    feature_means = feature_array.mean(axis=0).tolist()
+    feature_stds = feature_array.std(axis=0).tolist()
+
     # Save training data
     training_data = {
         'num_samples': len(training_samples),
         'feature_names': [
             'v_ego', 'roll_lataccel', 'a_ego', 'error',
-            'error_integral', 'error_derivative', 
+            'error_integral', 'error_derivative',
             'future_lataccel_mean', 'future_lataccel_std'
         ],
+        'feature_stats': {
+            'mean': feature_means,
+            'std': feature_stds,
+        },
         'samples': [
             {
                 'features': sample[0],


### PR DESCRIPTION
## Summary
- compute per-feature mean/std during Blender training data generation and save as `feature_stats`
- support feature_stats in alternate training data generators
- normalize training features in `train_blender_net_from_json` and add optional normalization in `extract_features`

## Testing
- `python generate_blender_training_data.py --samples 10 --output-path /tmp/train.json --data-seed 1`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68901e83ff18832db3c82e179f5c3805