### PR TITLE
Raise error for missing blended 2-PID params and write params file after Stage 1

### DIFF
--- a/controllers/blended_2pid.py
+++ b/controllers/blended_2pid.py
@@ -11,19 +11,20 @@ class Controller(BaseController):
     def __init__(self):
         # Load parameters from json file
         params_file = Path(__file__).parent.parent / "blended_2pid_params.json"
-        if params_file.exists():
+        try:
             with open(params_file, 'r') as f:
                 params = json.load(f)
-            
+
             low_gains = params['low_gains']
             high_gains = params['high_gains']
-            
-            print(f"Loaded blended 2-PID parameters (cost: {params.get('best_cost', 'N/A'):.2f})")
-        else:
-            # Fallback to default parameters
-            low_gains = [0.3, 0.03, -0.1]
-            high_gains = [0.2, 0.01, -0.05]
-            print("Using fallback blended 2-PID parameters")
+
+            cost = params.get('best_cost', float('nan'))
+            print(f"Loaded blended 2-PID parameters (cost: {cost:.2f})")
+        except (FileNotFoundError, json.JSONDecodeError, KeyError, TypeError) as e:
+            raise FileNotFoundError(
+                f"Could not load blended_2pid parameters from {params_file}. "
+                "Ensure Stage 1 ran and produced a valid params file."
+            ) from e
         
         # Initialize specialized PID controllers
         self.low_speed_pid = SpecializedPID(low_gains[0], low_gains[1], low_gains[2], "LowSpeed")

--- a/optimization/blended_2pid_optimizer.py
+++ b/optimization/blended_2pid_optimizer.py
@@ -197,5 +197,17 @@ def main():
     optimizer.print_top_results(results, top_n=15)
     optimizer.save_comprehensive_results(results)
 
+    if optimizer.best_params is None:
+        raise RuntimeError("Optimization completed without finding valid parameters")
+
+    params_path = base_dir / "blended_2pid_params.json"
+    with open(params_path, "w") as f:
+        json.dump({
+            "low_gains": optimizer.best_params[0],
+            "high_gains": optimizer.best_params[1],
+            "best_cost": optimizer.best_cost,
+        }, f, indent=2)
+    print(f"Saved best parameters to {params_path}")
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- require blended_2pid_params.json with detailed error instead of falling back to hard-coded gains
- save best parameters to blended_2pid_params.json at end of Stage 1 optimization

## Testing
- `pytest` *(fails: AttributeError: <module 'optimization.blender_tournament_optimizer' has no attribute 'train_architecture'>)*

------
https://chatgpt.com/codex/tasks/task_e_689161077978832d88c3982a00a5be38