### PR TITLE
Raise error when PID archive lacks cost data

### DIFF
--- a/controllers/neural_blended.py
+++ b/controllers/neural_blended.py
@@ -56,8 +56,9 @@ class Controller(BaseController):
             if valid_entries:
                 best_combo = min(valid_entries, key=lambda x: x['stats']['avg_total_cost'])
             else:
-                # Fallback to first archive entry if no valid stats
-                best_combo = archive['archive'][0]
+                raise RuntimeError(
+                    f"No valid 'avg_total_cost' values found in tournament archive: {archive_path}"
+                )
             
             pid1_params = best_combo['low_gains']
             pid2_params = best_combo['high_gains']


### PR DESCRIPTION
## Summary
- Raise a `RuntimeError` in `NeuralBlended` PID parameter loader when no `avg_total_cost` values exist and include archive path for easier debugging.

## Testing
- `python -m pytest` *(fails: optimization.blender_tournament_optimizer has no attribute 'train_architecture')*


------
https://chatgpt.com/codex/tasks/task_e_6891611595b8832da5f603fbd38054d2