### PR TITLE
Raise error when BlenderNet pretrained weights missing

### DIFF
--- a/optimization/blender_tournament_optimizer.py
+++ b/optimization/blender_tournament_optimizer.py
@@ -93,11 +93,20 @@ def train_model_with_hyperparameters(hyperparams, training_data_path, pretrained
     )
 
     # Load the weights from the pre-trained model
-    if pretrained_path and Path(pretrained_path).exists():
+    if pretrained_path:
+        if not Path(pretrained_path).exists():
+            raise FileNotFoundError(
+                f"Pretrained BlenderNet weights not found at '{pretrained_path}'. "
+                "Generate weights with `python train_blender.py` or supply a valid file."
+            )
         try:
             model.load_state_dict(torch.load(pretrained_path, weights_only=False))
         except Exception as e:
-            print(f"⚠️ Could not load pre-trained weights: {e}. Training from scratch.")
+            raise RuntimeError(
+                "Failed to load pretrained BlenderNet weights from "
+                f"'{pretrained_path}': {e}. "
+                "Generate weights with `python train_blender.py` or supply a valid file."
+            ) from e
 
     # Train the model
     train_blender_net_from_json(

--- a/optimization/tests/test_pretrained_weights.py
+++ b/optimization/tests/test_pretrained_weights.py
@@ -1,0 +1,45 @@
+import types
+import sys
+import pytest
+from optimization import blender_tournament_optimizer as bto
+
+
+def test_missing_pretrained_weights_raises(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    dummy_nb = types.ModuleType("neural_blender_net")
+
+    class DummyNet:
+        def __init__(self, hidden_sizes, dropout_rate):
+            pass
+
+        def load_state_dict(self, state_dict):
+            pass
+
+    def dummy_train(*args, **kwargs):
+        pass
+
+    dummy_nb.BlenderNet = DummyNet
+    dummy_nb.train_blender_net_from_json = dummy_train
+    monkeypatch.setitem(sys.modules, "neural_blender_net", dummy_nb)
+
+    dummy_torch = types.ModuleType("torch")
+
+    def dummy_load(path, weights_only=False):
+        return {}
+
+    dummy_torch.load = dummy_load
+    monkeypatch.setitem(sys.modules, "torch", dummy_torch)
+
+    hyperparams = {
+        'id': 'testid',
+        'hidden_sizes': [32, 16],
+        'dropout_rate': 0.1,
+        'learning_rate': 0.001,
+        'epochs': 1,
+        'batch_size': 1,
+        'cost': float('inf'),
+    }
+
+    with pytest.raises(FileNotFoundError, match="train_blender.py"):
+        bto.train_model_with_hyperparameters(hyperparams, 'train.json', pretrained_path='missing.pth')


### PR DESCRIPTION
## Summary
- fail fast in `train_model_with_hyperparameters` when a provided pretrained weights path is missing or invalid, suggesting `python train_blender.py`
- add regression test for missing pretrained weights and update ONNX cleanup tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689161867c70832d9aacea093077b918