### PR TITLE
Handle archive seeding errors

### DIFF
--- a/optimization/tests/test_tournament.py
+++ b/optimization/tests/test_tournament.py
@@ -88,3 +88,11 @@ def test_generate_new_variation_and_count():
         assert ps.rounds_survived == 0
         # Ensure exploration: at least one gain differs
         assert (ps.low_gains != base_low_gains or ps.high_gains != base_high_gains)
+
+
+def test_initialize_population_invalid_archive_raises(tmp_path):
+    archive_path = tmp_path / "archive.json"
+    archive_path.write_text("{}")
+    with pytest.raises(RuntimeError) as exc:
+        topt.initialize_population(5, seed_from_archive=str(archive_path))
+    assert str(archive_path) in str(exc.value)

--- a/optimization/tournament_optimizer.py
+++ b/optimization/tournament_optimizer.py
@@ -165,16 +165,21 @@ def initialize_population(
     init_seed: Optional[int] = None
 ) -> List[ParameterSet]:
     population: List[ParameterSet] = []
-    if seed_from_archive and Path(seed_from_archive).exists():
+    if seed_from_archive:
+        archive_path = Path(seed_from_archive)
+        if not archive_path.exists():
+            raise FileNotFoundError(f"Archive file not found: {archive_path}")
         try:
-            champions = load_champions_from_file(seed_from_archive, n)
+            champions = load_champions_from_file(str(archive_path), n)
             for i, champ in enumerate(champions):
                 low, high = extract_gains_from_champion(champ)
                 ps = ParameterSet(low, high)
                 ps.id = f"champion_{i}"
                 population.append(ps)
-        except:
-            pass
+        except Exception as e:
+            raise RuntimeError(
+                f"Failed to initialize population from archive '{archive_path}'"
+            ) from e
     remaining = n - len(population)
     rng = np.random.default_rng(init_seed)
     for _ in range(remaining):


### PR DESCRIPTION
## Summary
- propagate archive seeding failures with explicit errors in tournament optimizer
- add regression test for invalid archive input
- expose train/evaluate helpers for neural tournament tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689161a32620832d8d23cb20bf599234