### PR TITLE
Raise errors from evaluators

### DIFF
--- a/optimization/tournament_optimizer.py
+++ b/optimization/tournament_optimizer.py
@@ -136,8 +136,9 @@ def evaluate(ps: ParameterSet, data_files: List[str], model: TinyPhysicsModel, m
         for file in selected:
             cost, _, _ = run_rollout(file, module_name, model, debug=False)
             total_costs.append(cost["total_cost"])
-    except Exception as e:
-        logging.error("Evaluation failed for %s: %s", ps.id, e)
+    except Exception:
+        logging.exception("Evaluation failed for %s", ps.id)
+        raise
     finally:
         cleanup_controllers(prefix=f"temp_{ps.id.replace('-', '')}")
         if full_module and full_module in sys.modules:


### PR DESCRIPTION
## Summary
- Propagate rollout failures in tournament optimizer by logging and re-raising evaluation errors.
- Ensure blended 2PID optimizer halts on rollout issues and combo errors, with proper cleanup and logging.

## Testing
- `pytest` *(fails: AttributeError: module 'optimization.blender_tournament_optimizer' has no attribute 'train_architecture')*


------
https://chatgpt.com/codex/tasks/task_e_689161ab7044832d90d1030a67da1068